### PR TITLE
Allow disabling wrap-around

### DIFF
--- a/pc-bufsw.el
+++ b/pc-bufsw.el
@@ -139,7 +139,12 @@ reported by some terminals when pressing those keys that Emacs does not recogniz
 there is no input during this interval the last choosen buffer
 becomes current."
     :group 'pc-bufsw
-    :type 'number))
+    :type 'number)
+
+  (defcustom pc-bufsw-wrap-index t
+    "Wrap to the other end of the buffer list when attempting to navigate past its edge."
+    :group 'pc-bufsw
+    :type 'boolean))
 
 (defvar pc-bufsw--walk-vector nil
   "Vector of buffers to navigate during buffer switch.
@@ -264,8 +269,11 @@ top.")
 
 (defun pc-bufsw--choose-next-index (direction)
   (setq pc-bufsw--cur-index
-	(mod (+ pc-bufsw--cur-index direction)
-	     (length pc-bufsw--walk-vector))))
+	(if pc-bufsw-wrap-index
+	    (mod (+ pc-bufsw--cur-index direction)
+		 (length pc-bufsw--walk-vector))
+	  (max 0 (min (1- (length pc-bufsw--walk-vector))
+		      (+ pc-bufsw--cur-index direction))))))
 
 (defun pc-bufsw--finish ()
   ;; Called on switch mode close.


### PR DESCRIPTION
Thanks for this package. I found it to be a great complement to helm-for-files.

Sometimes I press Control+Shift+Tab after the timeout expires, or press it too many times. Wrapping around to the least recently used buffer is, however, never what I need, so I wanted an option to disable this behaviour. So, here is a patch adding an option to disable wrapping around the buffer list.