### PR TITLE
Fix working with killed buffers

### DIFF
--- a/pc-bufsw.el
+++ b/pc-bufsw.el
@@ -304,7 +304,7 @@ Buffers are odered from most to least recently used.")
 (defun pc-bufsw--can-work-buffer (buffer)
   ;; Return nil if buffer is not suitable for switch.
   (let ((name (buffer-name buffer)))
-    (not (equal ?\  (aref name 0)))))
+    (and name (not (equal ?\  (aref name 0))))))
 
 (defun pc-bufsw--show-buffers-names ()
   ;; Echo buffer list. Current buffer marked by <>.


### PR DESCRIPTION
Apparently, very rarely a killed buffer can sneak its way into our buffer ring. Its `buffer-name` is nil, so when that happens `pc-bufsw` working. Detect this situation and ignore it.